### PR TITLE
[ENH] make table optional

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[dev]
+          python -m pip install .[dev,tables]
       - name: Build docs
         run: |
           cd doc

--- a/afqinsight/h5io.py
+++ b/afqinsight/h5io.py
@@ -36,7 +36,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import numpy as np
-import tables
 import warnings
 from scipy import sparse
 from dipy.utils.optpkg import optional_package

--- a/afqinsight/h5io.py
+++ b/afqinsight/h5io.py
@@ -39,6 +39,17 @@ import numpy as np
 import tables
 import warnings
 from scipy import sparse
+from dipy.utils.optpkg import optional_package
+
+
+tables_msg = (
+    "To use AFQ-Insight's h5io classes, you will need to have tables "
+    "installed. You can do this by installing afqinsight with `pip install "
+    "afqinsight[tables]`, or by separately installing these packages with "
+    "`pip install tables`."
+)
+tables, HAS_TABLES, _ = optional_package("tables", trip_msg=tables_msg)
+
 
 try:
     import pandas as pd

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ include_package_data = True
 packages = find:
 
 [options.extras_require]
-hdf5 = 
+tables = 
     tables==3.9.1
 torch =
     torch

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     seaborn==0.13.0
     scikit-learn==1.2.1
     sklearn_pandas>=2.0.0
-    tables==3.9.1
     tqdm
     statsmodels==0.14.0
     copt==0.9.1
@@ -50,6 +49,8 @@ include_package_data = True
 packages = find:
 
 [options.extras_require]
+hdf5 = 
+    tables==3.9.1
 torch =
     torch
 tf =

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ maint =
     rapidfuzz
 
 all =
+    %(tables)s
     %(torch)s
     %(tf)s
     %(dev)s


### PR DESCRIPTION
This makes afq insight dependent on hdf5, which requires installation (usually by conda). Without this, I believe afq-insight is entirely pip-installable, which is much more convenient for new users.